### PR TITLE
Moved tape to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "dependencies": {
     "request": "^2.36.0",
-    "tape": "^2.13.1",
     "xhr": "^1.6.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "^2.13.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/maxogden/nets.git"


### PR DESCRIPTION
Is there a reason why `tape` is not specified as a dev dependency?
Moved to make `npm install --production` work as expected.