### PR TITLE
Return value from xhr/request

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ var req = require('request')
 module.exports = Nets
 
 function Nets(uri, opts, cb) {
-  req(uri, opts, cb)
+  return req(uri, opts, cb)
 }

--- a/test.js
+++ b/test.js
@@ -111,6 +111,11 @@ test('DELETE', function(t) {
   })
 })
 
+test('returns value', function(t) {
+  t.ok(nets({url: binUrl + '/' + bin.name},function() {}), 'nets has return value')
+  t.end()
+});
+
 function getRequests(cb) {
   nets({
     url: binUrl + '/api/v1/bins/' + bin.name + '/requests',


### PR DESCRIPTION
Currently no way to grab the xhr before the request completes. Added return.