### PR TITLE
Update xhr and request

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "request": "xhr"
   },
   "dependencies": {
-    "request": "^2.36.0",
+    "request": "^2.53.0",
     "tape": "^2.13.1",
     "xhr": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "request": "^2.36.0",
     "tape": "^2.13.1",
-    "xhr": "^1.6.1"
+    "xhr": "^2.0.1"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
`xhr` is now at version 2, and behaves more like `request`: https://github.com/Raynos/xhr/issues/67

There was also some nasty API change in request 2.59.0 (I think) having to do with the default request body JSON parsing behavior. I don't know the details but @bcoe can provide more info if necessary. I think it would be nice to roll out these two updates together for nets 3.0, because they're both kinda breaky-changey.